### PR TITLE
B-Front-06.06.2020-7-Major

### DIFF
--- a/src/component/homepage-view/css/homepage-link.css
+++ b/src/component/homepage-view/css/homepage-link.css
@@ -96,6 +96,11 @@
         color:#D9183B;
     }   
     .homepageLinkTitle{
-        margin-left: 5px;
+        margin-left: 5px;        
+        width: 90%;
+        white-space: nowrap; 
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }


### PR DESCRIPTION
There is still room for improvement! Nonetheless, the current request will be accepted and merged. 
The **B-Front-06.06.2020-7.1-Normal** is created to resolve the remaining issues. 

Devices (Smart phones and tablets) which use /*DESKTOP*/ styles including iphoneX, ipad, ipadPro
Still encounter the problem. Heavy changes on the /*DESKTOP*/ style may affect the desktop device. 
Although the link text is clipped, the remaining '...' collides with the link icon in the mentioned devices. 